### PR TITLE
Update WhosWho to 2.0, update dependencies (#6)

### DIFF
--- a/fr.masson_informatique.WhosWho.yml
+++ b/fr.masson_informatique.WhosWho.yml
@@ -21,8 +21,8 @@ modules:
       --prefix=${FLATPAK_DEST} "chardet" --no-build-isolation
     sources:
     - type: file
-      url: https://files.pythonhosted.org/packages/74/8f/8fc49109009e8d2169d94d72e6b1f4cd45c13d147ba7d6170fb41f22b08f/chardet-5.1.0-py3-none-any.whl
-      sha256: 362777fb014af596ad31334fde1e8c327dfdb076e1960d1694662d46a6917ab9
+      url: https://files.pythonhosted.org/packages/38/6f/f5fbc992a329ee4e0f288c1fe0e2ad9485ed064cac731ed2fe47dcc38cbf/chardet-5.2.0-py3-none-any.whl
+      sha256: e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970
     cleanup:
     - "/bin/*"
 
@@ -34,17 +34,17 @@ modules:
       --prefix=${FLATPAK_DEST} "scikit-build" --no-build-isolation
     sources:
     - type: file
-      url: https://files.pythonhosted.org/packages/d2/a3/01d72e506afcf919c191de587c3f77ee7355b0b28951eb1fbc2753bc9d77/scikit_build-0.17.3-py3-none-any.whl
-      sha256: 4bf75dcf628513badb7cc8a926414155ab3db3273f5f8c243092e7a2bdbdd5c9
+      url: https://files.pythonhosted.org/packages/fa/af/b3ef8fe0bb96bf7308e1f9d196fc069f0c75d9c74cfaad851e418cc704f4/scikit_build-0.17.6-py3-none-any.whl
+      sha256: 18bd55e81841106eec93f30a297df4f301003791c41be46ef6428d58bd42d6b3
     - type: file
-      url: https://files.pythonhosted.org/packages/f4/2c/c90a3adaf0ddb70afe193f5ebfb539612af57cffe677c3126be533df3098/distro-1.8.0-py3-none-any.whl
-      sha256: 99522ca3e365cac527b44bde033f64c6945d90eb9f769703caaec52b09bbd3ff
+      url: https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl
+      sha256: 7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
     - type: file
-      url: https://files.pythonhosted.org/packages/ab/c3/57f0601a2d4fe15de7a553c00adbc901425661bf048f2a22dfc500caf121/packaging-23.1-py3-none-any.whl
-      sha256: 994793af429502c4ea2ebf6bf664629d07c1a9fe974af92966e4b8d2df7edc61
+      url: https://files.pythonhosted.org/packages/49/df/1fceb2f8900f8639e278b056416d49134fb8d84c5942ffaa01ad34782422/packaging-24.0-py3-none-any.whl
+      sha256: 2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5
     - type: file
-      url: https://files.pythonhosted.org/packages/6c/10/a7d0fa5baea8fe7b50f448ab742f26f52b80bfca85ac2be9d35cdd9a3246/pyparsing-3.0.9-py3-none-any.whl
-      sha256: 5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc
+      url: https://files.pythonhosted.org/packages/9d/ea/6d76df31432a0e6fdf81681a895f009a4bb47b3c39036db3e1b528191d52/pyparsing-3.1.2-py3-none-any.whl
+      sha256: f9db75911801ed778fe61bb643079ff86601aca99fcae6345aa67292038fb742
     - type: file
       url: https://files.pythonhosted.org/packages/97/75/10a9ebee3fd790d20926a90a2547f0bf78f371b2f13aa822c759680ca7b9/tomli-2.0.1-py3-none-any.whl
       sha256: 939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc
@@ -150,8 +150,8 @@ modules:
     sources:
     - type: git
       url: https://github.com/Itseez/opencv.git
-      tag: 4.7.0
-      commit: 725e440d278aca07d35a5e8963ef990572b07316
+      tag: 4.9.0
+      commit: dad8af6b17f8e60d7b95a1203a1b4d22f56574cf
     cleanup:
     - "/bin/*"
     - "/share/licenses/*"
@@ -186,8 +186,8 @@ modules:
       --prefix=${FLATPAK_DEST} "Pillow" --no-build-isolation
     sources:
     - type: file
-      url: https://files.pythonhosted.org/packages/00/d5/4903f310765e0ff2b8e91ffe55031ac6af77d982f0156061e20a4d1a8b2d/Pillow-9.5.0.tar.gz
-      sha256: bf548479d336726d7a0eceb6e767e179fbde37833ae42794602631a070d630f1
+      url: https://files.pythonhosted.org/packages/ef/43/c50c17c5f7d438e836c169e343695534c38c77f60e7c90389bd77981bc21/pillow-10.3.0.tar.gz
+      sha256: 9d2455fbf44c914840c793e89aa82d0e1763a14253a000743719ae5946814b2d
 
   - name: python3-Willow
     buildsystem: simple
@@ -196,8 +196,8 @@ modules:
       --prefix=${FLATPAK_DEST} "Willow" --no-build-isolation
     sources:
     - type: file
-      url: https://files.pythonhosted.org/packages/87/11/c82a6ec5f8e262cd547347c92258b82570dd1e57cca2b0c927af56c4f7ef/Willow-1.5-py3-none-any.whl
-      sha256: 8f885ae0e8311ec45a943d5db2af77cc2b44d3c5ba4d6a053012a67e861ca829
+      url: https://files.pythonhosted.org/packages/95/7a/a48cf90bbf226f793d830c3bbdb7f0c4aa8087c08ce84cc864a1c882a457/willow-1.8.0-py3-none-any.whl
+      sha256: 48ccf5ce48ccd29c37a32497cd7af50983f8570543c4de2988b15d583efc66be
     - type: file
       url: https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl
       sha256: 7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25
@@ -228,8 +228,8 @@ modules:
     - "--without-x"
     sources:
     - type: archive
-      url: https://imagemagick.org/archive/releases/ImageMagick-7.1.1-8.tar.xz
-      sha256: 05a24995cb4ad1c1185255fa0d65c24842a71972336cda20f9fbd330299d160a
+      url: https://imagemagick.org/archive/releases/ImageMagick-7.1.1-32.tar.xz
+      sha256: e7a6b98f105e6b0f4f1b1e1d72f002262cc1a375b8c05b5f9e8dd2be438897d2
     cleanup:
     - "/bin/MagickCore-config"
     - "/bin/MagickWand-config"
@@ -241,5 +241,5 @@ modules:
       - pip3 install --prefix=${FLATPAK_DEST} --no-deps .
     sources:
       - type: archive
-        url: https://framagit.org/Yvan-Masson/WhosWho/-/archive/v1.9/WhosWho-v1.9.tar.gz
-        sha256: 0cdd044647e50f046f6b1dc010bb330c74e89ec17606d5de4b790782ce444849
+        url: https://framagit.org/Yvan-Masson/WhosWho/-/archive/v2.0/WhosWho-v2.0.tar.gz
+        sha256: b950ec2fe28bd14618a2d2a7ad0b0c315a5c44ab4c79f3db6bfa9df5b7210b7d


### PR DESCRIPTION
Numpy is not upgraded because I could not build the last version, which now requires Cython.